### PR TITLE
Fix/oauth providers registration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "todo-app",
       "version": "0.1.0",
       "dependencies": {
-        "@auth/prisma-adapter": "^2.7.2",
+        "@auth/prisma-adapter": "^2.7.4",
         "@prisma/client": "^6.0.0",
         "@radix-ui/react-checkbox": "^1.1.2",
         "@radix-ui/react-dialog": "^1.1.2",
@@ -118,15 +118,63 @@
       }
     },
     "node_modules/@auth/prisma-adapter": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@auth/prisma-adapter/-/prisma-adapter-2.7.2.tgz",
-      "integrity": "sha512-orznIVt6aQMoJ4/rfWFSpRPU8LoZn6jVtDuEkZgLud2xSnCalq6x+hX+rqlk4E5LM13NW1GIJojOPQnM4aM4Gw==",
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/@auth/prisma-adapter/-/prisma-adapter-2.7.4.tgz",
+      "integrity": "sha512-3T/X94R9J1sxOLQtsD3ijIZ0JGHPXlZQxRr/8NpnZBJ3KGxun/mNsZ1MwMRhTxy0mmn9JWXk7u9+xCcVn0pu3A==",
       "license": "ISC",
       "dependencies": {
-        "@auth/core": "0.37.2"
+        "@auth/core": "0.37.4"
       },
       "peerDependencies": {
         "@prisma/client": ">=2.26.0 || >=3 || >=4 || >=5"
+      }
+    },
+    "node_modules/@auth/prisma-adapter/node_modules/@auth/core": {
+      "version": "0.37.4",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.37.4.tgz",
+      "integrity": "sha512-HOXJwXWXQRhbBDHlMU0K/6FT1v+wjtzdKhsNg0ZN7/gne6XPsIrjZ4daMcFnbq0Z/vsAbYBinQhhua0d77v7qw==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^5.9.6",
+        "oauth4webapi": "^3.1.1",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^6.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@auth/prisma-adapter/node_modules/preact": {
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/@auth/prisma-adapter/node_modules/preact-render-to-string": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": ">=10"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -9,13 +9,12 @@
     "start": "next start",
     "lint": "next lint",
     "format": "prettier . --write",
-    "setup": "npx prisma generate && npx prisma migrate deploy",
-    "build:seed": "tsc prisma/seed.ts --outDir prisma/compiled",
-    "seed": "npm run build:seed && npx prisma db seed",
-    "admin": "npx prisma studio"
+    "setup": "prisma generate && prisma migrate deploy",
+    "seed": "prisma db seed",
+    "admin": "prisma studio"
   },
   "prisma": {
-    "seed": "node prisma/compiled/seed.js"
+    "seed": "npx tsx prisma/seed.ts"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.7.4",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "seed": "node prisma/compiled/seed.js"
   },
   "dependencies": {
-    "@auth/prisma-adapter": "^2.7.2",
+    "@auth/prisma-adapter": "^2.7.4",
     "@prisma/client": "^6.0.0",
     "@radix-ui/react-checkbox": "^1.1.2",
     "@radix-ui/react-dialog": "^1.1.2",

--- a/prisma/migrations/20241130110612_make_password_nullable_for_oauth_case/migration.sql
+++ b/prisma/migrations/20241130110612_make_password_nullable_for_oauth_case/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "password" DROP NOT NULL;

--- a/prisma/migrations/20241130113923_add_image_to_user_model/migration.sql
+++ b/prisma/migrations/20241130113923_add_image_to_user_model/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "image" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,8 +36,9 @@ model User {
   id       String  @id @default(uuid())
   verified Boolean @default(false)
   email    String  @unique
+  image    String?
   name     String
-  password String
+  password String?
 
   tokens      Token[]
   accounts    Account[]

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,11 +1,21 @@
-import { PrismaClient, Task, User, Assignment, TaskRole } from '@prisma/client';
+import {
+  PrismaClient,
+  Task,
+  User as PrismaUser,
+  Assignment,
+  TaskRole,
+} from '@prisma/client';
 import * as fs from 'fs';
 import * as bcrypt from 'bcryptjs';
+
+type MockUser = Omit<PrismaUser, 'id' | 'password'> & {
+  password: string;
+};
 
 const prisma = new PrismaClient();
 const usersData = JSON.parse(
   fs.readFileSync('prisma/mocks/mock-users.json', 'utf8'),
-) as Omit<User, 'id'>[];
+) as MockUser[];
 const tasksData = JSON.parse(
   fs.readFileSync('prisma/mocks/mock-tasks.json', 'utf8'),
 ) as Omit<Task, 'id'>[];
@@ -19,7 +29,7 @@ const importantUsers = [
   },
 ];
 
-const hashPasswords = (users: Omit<User, 'id'>[]) => {
+const hashPasswords = (users: MockUser[]) => {
   console.group('Hashing passwords...');
   for (let i = 0; i < users.length; i++) {
     users[i].password = bcrypt.hashSync(users[i].password, 1);

--- a/src/actions/auth/controller.ts
+++ b/src/actions/auth/controller.ts
@@ -29,7 +29,7 @@ export const register = async ({
 }: {
   name: string;
   email: User['email'];
-  password: User['password'];
+  password: string;
 }) => {
   const existingUser = await userService.getUserByEmail(email);
 
@@ -60,7 +60,7 @@ export const login = async ({
   password,
 }: {
   email: User['email'];
-  password: User['password'];
+  password: string;
 }) => {
   try {
     await signIn('credentials', { email, password });
@@ -162,7 +162,7 @@ export const resetPassword = async ({
   token,
 }: {
   token: Token['token'];
-  newPassword: User['password'];
+  newPassword: string;
 }) => {
   const { verifiedToken, user } = await getVerifiedToken(token);
 

--- a/src/components/task-card.tsx
+++ b/src/components/task-card.tsx
@@ -65,7 +65,7 @@ export const TaskCard = ({
       {priority && (
         <div
           style={{ backgroundColor: getPriorityColor(priority) }}
-          className={cn('top-0 w-full absolute h-1')}
+          className={cn('left-0 w-1 absolute h-full')}
         />
       )}
       <CardHeader className="p-4 space-y-0 ">

--- a/src/lib/prisma-adapter.ts
+++ b/src/lib/prisma-adapter.ts
@@ -1,0 +1,39 @@
+import { PrismaAdapter } from '@auth/prisma-adapter';
+import { PrismaClient } from '@prisma/client';
+
+function stripUndefined<T>(obj: T) {
+  const data = {} as T;
+  for (const key in obj) if (obj[key] !== undefined) data[key] = obj[key];
+  return { data };
+}
+
+export const CustomPrismaAdapter = (
+  prisma: PrismaClient,
+): ReturnType<typeof PrismaAdapter> => {
+  const adapter = PrismaAdapter(prisma);
+  return {
+    ...adapter,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    createUser: async ({ id, ...data }) => {
+      const {
+        data: { emailVerified, ...strippedData },
+      } = stripUndefined(data);
+
+      const user = await prisma.user.create({
+        data: {
+          ...strippedData,
+          name: data.name || 'Anonymous',
+          verified: !!emailVerified,
+        },
+      });
+
+      return {
+        ...data,
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        image: user.image,
+      };
+    },
+  };
+};


### PR DESCRIPTION
Fix: Handle missing password field for OAuth providers

Issue: When a user registers via an OAuth provider (e.g., Google), an error was thrown because the password field in the user db model was required. OAuth providers do not supply a password, causing the registration process to fail.

Solution:
- Made the password field nullable in the user model to accommodate OAuth providers that do not provide a password.
- Customized the Prisma adapter (based on the existing one) to better align with the current database schema and improve compatibility.